### PR TITLE
Add OSX link for 3.0 release

### DIFF
--- a/versions/3.0.yaml
+++ b/versions/3.0.yaml
@@ -1,3 +1,4 @@
 binaries:
+  osx: https://swift.org/builds/swift-3.0-release/xcode/swift-3.0-RELEASE/swift-3.0-RELEASE-osx.pkg
   ubuntu14.04: https://swift.org/builds/swift-3.0-release/ubuntu1404/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu14.04.tar.gz
   ubuntu15.10: https://swift.org/builds/swift-3.0-release/ubuntu1510/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu15.10.tar.gz


### PR DESCRIPTION
Would appreciate a double-check but [`https://swift.org/builds/swift-3.0-release/xcode/swift-3.0-RELEASE/swift-3.0-RELEASE-osx.pkg`](https://swift.org/builds/swift-3.0-release/xcode/swift-3.0-RELEASE/swift-3.0-RELEASE-osx.pkg) seems to be the right url.