### PR TITLE
Removing GMs, PREVIEW versions

### DIFF
--- a/versions/3.0-GM-CANDIDATE.yaml
+++ b/versions/3.0-GM-CANDIDATE.yaml
@@ -1,4 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0-GM-CANDIDATE/xcode/swift-3.0-GM-CANDIDATE/swift-3.0-GM-CANDIDATE-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0-GM-CANDIDATE/ubuntu1404/swift-3.0-GM-CANDIDATE/swift-3.0-GM-CANDIDATE-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-GM-CANDIDATE/ubuntu1510/swift-3.0-GM-CANDIDATE/swift-3.0-GM-CANDIDATE-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-1.yaml
+++ b/versions/3.0-PREVIEW-1.yaml
@@ -1,3 +1,0 @@
-binaries:
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-1/ubuntu1404/swift-3.0-PREVIEW-1/swift-3.0-PREVIEW-1-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-1/ubuntu1510/swift-3.0-PREVIEW-1/swift-3.0-PREVIEW-1-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-2.yaml
+++ b/versions/3.0-PREVIEW-2.yaml
@@ -1,3 +1,0 @@
-binaries:
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-2/ubuntu1404/swift-3.0-PREVIEW-2/swift-3.0-PREVIEW-2-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-2/ubuntu1510/swift-3.0-PREVIEW-2/swift-3.0-PREVIEW-2-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-3.yaml
+++ b/versions/3.0-PREVIEW-3.yaml
@@ -1,4 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0-preview-3/xcode/swift-3.0-PREVIEW-3/swift-3.0-PREVIEW-3-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-3/ubuntu1404/swift-3.0-PREVIEW-3/swift-3.0-PREVIEW-3-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-3/ubuntu1510/swift-3.0-PREVIEW-3/swift-3.0-PREVIEW-3-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-4.yaml
+++ b/versions/3.0-PREVIEW-4.yaml
@@ -1,4 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0-preview-4/xcode/swift-3.0-PREVIEW-4/swift-3.0-PREVIEW-4-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-4/ubuntu1404/swift-3.0-PREVIEW-4/swift-3.0-PREVIEW-4-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-4/ubuntu1510/swift-3.0-PREVIEW-4/swift-3.0-PREVIEW-4-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-5.yaml
+++ b/versions/3.0-PREVIEW-5.yaml
@@ -1,4 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0-preview-5/xcode/swift-3.0-PREVIEW-5/swift-3.0-PREVIEW-5-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-5/ubuntu1404/swift-3.0-PREVIEW-5/swift-3.0-PREVIEW-5-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-5/ubuntu1510/swift-3.0-PREVIEW-5/swift-3.0-PREVIEW-5-ubuntu15.10.tar.gz

--- a/versions/3.0-PREVIEW-6.yaml
+++ b/versions/3.0-PREVIEW-6.yaml
@@ -1,4 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0-preview-6/xcode/swift-3.0-PREVIEW-6/swift-3.0-PREVIEW-6-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0-preview-6/ubuntu1404/swift-3.0-PREVIEW-6/swift-3.0-PREVIEW-6-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0-preview-6/ubuntu1510/swift-3.0-PREVIEW-6/swift-3.0-PREVIEW-6-ubuntu15.10.tar.gz

--- a/versions/3.0.1-GM-CANDIDATE.yaml
+++ b/versions/3.0.1-GM-CANDIDATE.yaml
@@ -1,5 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0.1-GM-CANDIDATE/xcode/swift-3.0.1-GM-CANDIDATE/swift-3.0.1-GM-CANDIDATE-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0.1-GM-CANDIDATE/ubuntu1404/swift-3.0.1-GM-CANDIDATE/swift-3.0.1-GM-CANDIDATE-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0.1-GM-CANDIDATE/ubuntu1510/swift-3.0.1-GM-CANDIDATE/swift-3.0.1-GM-CANDIDATE-ubuntu15.10.tar.gz
-  ubuntu16.04: https://swift.org/builds/swift-3.0.1-GM-CANDIDATE/ubuntu1604/swift-3.0.1-GM-CANDIDATE/swift-3.0.1-GM-CANDIDATE-ubuntu16.04.tar.gz

--- a/versions/3.0.1-PREVIEW-1.yaml
+++ b/versions/3.0.1-PREVIEW-1.yaml
@@ -1,5 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0.1-preview-1/xcode/swift-3.0.1-PREVIEW-1/swift-3.0.1-PREVIEW-1-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0.1-preview-1/ubuntu1404/swift-3.0.1-PREVIEW-1/swift-3.0.1-PREVIEW-1-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0.1-preview-1/ubuntu1510/swift-3.0.1-PREVIEW-1/swift-3.0.1-PREVIEW-1-ubuntu15.10.tar.gz
-  ubuntu16.04: https://swift.org/builds/swift-3.0.1-preview-1/ubuntu1604/swift-3.0.1-PREVIEW-1/swift-3.0.1-PREVIEW-1-ubuntu16.04.tar.gz

--- a/versions/3.0.1-PREVIEW-2.yaml
+++ b/versions/3.0.1-PREVIEW-2.yaml
@@ -1,5 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0.1-preview-2/xcode/swift-3.0.1-PREVIEW-2/swift-3.0.1-PREVIEW-2-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0.1-preview-2/ubuntu1404/swift-3.0.1-PREVIEW-2/swift-3.0.1-PREVIEW-2-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0.1-preview-2/ubuntu1510/swift-3.0.1-PREVIEW-2/swift-3.0.1-PREVIEW-2-ubuntu15.10.tar.gz
-  ubuntu16.04: https://swift.org/builds/swift-3.0.1-preview-2/ubuntu1604/swift-3.0.1-PREVIEW-2/swift-3.0.1-PREVIEW-2-ubuntu16.04.tar.gz

--- a/versions/3.0.1-PREVIEW-3.yaml
+++ b/versions/3.0.1-PREVIEW-3.yaml
@@ -1,5 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0.1-preview-3/xcode/swift-3.0.1-PREVIEW-3/swift-3.0.1-PREVIEW-3-osx.pkg
-  ubuntu14.04: https://swift.org/builds/swift-3.0.1-preview-3/ubuntu1404/swift-3.0.1-PREVIEW-3/swift-3.0.1-PREVIEW-3-ubuntu14.04.tar.gz
-  ubuntu15.10: https://swift.org/builds/swift-3.0.1-preview-3/ubuntu1510/swift-3.0.1-PREVIEW-3/swift-3.0.1-PREVIEW-3-ubuntu15.10.tar.gz
-  ubuntu16.04: https://swift.org/builds/swift-3.0.1-preview-3/ubuntu1604/swift-3.0.1-PREVIEW-3/swift-3.0.1-PREVIEW-3-ubuntu16.04.tar.gz

--- a/versions/3.0.2-PREVIEW-1.yaml
+++ b/versions/3.0.2-PREVIEW-1.yaml
@@ -1,3 +1,0 @@
-binaries:
-  osx: https://swift.org/builds/swift-3.0.2-preview-1/xcode/swift-3.0.2-PREVIEW-1/swift-3.0.2-PREVIEW-1-osx.pkg
-  ubuntu16.04: https://swift.org/builds/swift-3.0.2-preview-1/ubuntu1604/swift-3.0.2-PREVIEW-1/swift-3.0.2-PREVIEW-1-ubuntu16.04.tar.gz


### PR DESCRIPTION
@kylef Merge if you will

As suggested in #10

I personally would leave there just versions:
2.2.1
3.0
3.0.1
3.0.2

When 3.1 is released then just these:
2.2.1
3.0.2 (or higher of 3.0.x if released)
3.1.anything

But that's up to you...