### PR TITLE
Add 5.2

### DIFF
--- a/versions/5/5.2.yaml
+++ b/versions/5/5.2.yaml
@@ -1,0 +1,5 @@
+binaries:
+  osx: https://swift.org/builds/swift-5.2-release/xcode/swift-5.2-RELEASE/swift-5.2-RELEASE-osx.pkg
+  ubuntu16.04: https://swift.org/builds/swift-5.2-release/ubuntu1604/swift-5.2-RELEASE/swift-5.2-RELEASE-ubuntu16.04.tar.gz
+  ubuntu18.04: https://swift.org/builds/swift-5.2-release/ubuntu1804/swift-5.2-RELEASE/swift-5.2-RELEASE-ubuntu18.04.tar.gz
+version: '5.2'


### PR DESCRIPTION
Thank you very much for the quality work here @kylef 🚀 it's proving to be very useful in my efforts for helping get Swift working on Netlify!

This PR adds Swift 5.2 to the versions list now Apple have shipped it.

I haven't added Swift 5.1.5 - I'll let #79 deal with that.