### PR TITLE
Add Swift 5.3 release

### DIFF
--- a/versions/5/5.3.yaml
+++ b/versions/5/5.3.yaml
@@ -1,0 +1,9 @@
+binaries:
+  amazonlinux2: https://swift.org/builds/swift-5.3-release/amazonlinux2/swift-5.3-RELEASE/swift-5.3-RELEASE-amazonlinux2.tar.gz
+  centos7: https://swift.org/builds/swift-5.3-release/centos7/swift-5.3-RELEASE/swift-5.3-RELEASE-centos7.tar.gz
+  centos8: https://swift.org/builds/swift-5.3-release/centos8/swift-5.3-RELEASE/swift-5.3-RELEASE-centos8.tar.gz
+  osx: https://swift.org/builds/swift-5.3-release/xcode/swift-5.3-RELEASE/swift-5.3-RELEASE-osx.pkg
+  ubuntu16.04: https://swift.org/builds/swift-5.3-release/ubuntu1604/swift-5.3-RELEASE/swift-5.3-RELEASE-ubuntu16.04.tar.gz
+  ubuntu18.04: https://swift.org/builds/swift-5.3-release/ubuntu1804/swift-5.3-RELEASE/swift-5.3-RELEASE-ubuntu18.04.tar.gz
+  ubuntu20.04: https://swift.org/builds/swift-5.3-release/ubuntu2004/swift-5.3-RELEASE/swift-5.3-RELEASE-ubuntu20.04.tar.gz
+version: 5.3


### PR DESCRIPTION
This PR adds the newly released Swift 5.3 toolchains.